### PR TITLE
timestamp validation fixes

### DIFF
--- a/lib/bintoken.js
+++ b/lib/bintoken.js
@@ -3,6 +3,7 @@ const assert = require('./assert')
 const bindate = {
   toBuffer: (msTime) => {
     const unixTime = Math.floor(msTime / 1000)
+    assert(Number.isInteger(unixTime) && unixTime > 0 && unixTime <= 0xFFFFFFFF, 'invalid time')
     const buf = Buffer.alloc(4)
     buf.writeUInt32BE(unixTime)
     return buf
@@ -14,6 +15,8 @@ const bindate = {
 module.exports = {
   toBuffer: ({ type, publicKey, time = Date.now() }) => {
     assert(Number.isInteger(type) && type >= 0 && type <= 0xff, 'invalid bintoken type')
+    assert(Buffer.isBuffer(publicKey) && publicKey.length === 32, 'invalid public key')
+    assert(typeof time === 'number' && time > 0, 'invalid time')
 
     return Buffer.concat([Buffer.from([type]), publicKey, bindate.toBuffer(time)])
   },
@@ -25,6 +28,7 @@ module.exports = {
     const type = buf[0]
     const publicKey = buf.slice(1, 33)
     const time = bindate.fromBuffer(buf.slice(33, 37))
+    assert(typeof time === 'number' && time > 0, 'invalid time')
 
     return { type, publicKey, time }
   },

--- a/lib/index.js
+++ b/lib/index.js
@@ -69,7 +69,9 @@ const createBinauth = ({
       throw new BadRequestError(`challenge failed validation: ${err.message}`)
     }
 
-    if (challenge.time + challengeTTL < Date.now()) {
+    try {
+      assert(challenge.time + challengeTTL >= Date.now(), 'challenge expired')
+    } catch (err) {
       throw new UnauthorizedError('challenge expired')
     }
 
@@ -104,7 +106,9 @@ const createBinauth = ({
       throw new UnauthorizedError(`token failed to parse: ${err.message}`)
     }
 
-    if (verifiedToken.time + tokenTTL < Date.now()) {
+    try {
+      assert(verifiedToken.time + tokenTTL >= Date.now(), 'auth token expired')
+    } catch (err) {
       throw new UnauthorizedError('auth token expired')
     }
 


### PR DESCRIPTION
1. A bit more checks in `bintoken.js` itself (e.g. `time` to be present and in correct range)
2. Don't allow time = 0, just in case
3. Don't use `if (...) throw` constructions, as they fail open on e.g. `NaN`.
    I could have just negated the if (`if (!(... >= Date.now())) throw`), but we already have `assert` which is cleaner.