### PR TITLE
chore: update incorrect DEFAULT_CHALLENGE_TTL comment

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -6,7 +6,7 @@ const { BadRequestError, UnauthorizedError } = require('./errors')
 const TYPE_CHALLENGE = 1
 const TYPE_TOKEN = 2
 
-const DEFAULT_CHALLENGE_TTL = 60 * 1000 // 1 hour
+const DEFAULT_CHALLENGE_TTL = 60 * 1000 // 1 minute
 const DEFAULT_TOKEN_TTL = 24 * 60 * 60 * 1000 // 1 day
 
 const createBinauth = ({


### PR DESCRIPTION
The actual TTL is 1 minute (60000 ms).

Could use `ms`, but I didn't want to bring any extra packages.