### PR TITLE
ci: run checks on correct main branch

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -4,7 +4,7 @@ on:
     types: [opened, synchronize]
   push:
     branches:
-      - master
+      - main
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}


### PR DESCRIPTION
## Summary

The main branch here is called `main` and not `master`. Was wondering why the checks weren't running 😄.